### PR TITLE
Fix GHConfigIPlatformHelper ServiceLoader randomly failing on NeoForge

### DIFF
--- a/core/common/src/main/java/house/greenhouse/greenhouseconfig/platform/GHConfigIPlatformHelper.java
+++ b/core/common/src/main/java/house/greenhouse/greenhouseconfig/platform/GHConfigIPlatformHelper.java
@@ -100,16 +100,9 @@ public interface GHConfigIPlatformHelper extends ServiceLoader.Provider<GHConfig
 
 	@ApiStatus.Internal
 	static GHConfigIPlatformHelper load() {
-		var loaders = ServiceLoader.load(GHConfigIPlatformHelper.class);
-		// Maintain sanity
-		if (loaders.stream().findAny().isEmpty()) {
-			throw new IllegalStateException("No " + GHConfigIPlatformHelper.class.getName() + " implementation found");
-		}
+		var loaders = ServiceLoader.load(GHConfigIPlatformHelper.class, GHConfigIPlatformHelper.class.getClassLoader());
 
-		return loaders
-				.stream()
-				.findFirst()
-				.orElseThrow()
-				.get();
+		return loaders.findFirst().orElseThrow(() ->
+				new IllegalStateException("No " + GHConfigIPlatformHelper.class.getName() + " implementation found"));
 	}
 }


### PR DESCRIPTION
On NeoForge 1.21.1, about 25% of the time Greenhouse Config crashes during loading with the following error:

<img width="838" height="260" alt="image" src="https://github.com/user-attachments/assets/565d37f7-8f43-4e6a-907f-b66eb4c5a08e" />

This seems nonsensical because... the implementation class and definition are indeed in the same jar file! So why would this only work *sometimes*?

As it turns out this caused by a confluence of factors:

- on NeoForge, the early loading stages are parallelized
- the Java method `ServiceLoader.load(Class)` uses the thread's _context classloader_
- due to the parallelization, the _context classloader_ for a loading thread is not necessarily consistent

This does seem like a potential bug in NeoForge but might also just be an unavoidable race condition. Either way, we can just fix it by instead specifying our own classloader, since the class we want to load is in the same classpath!

This PR applies that fix to 1.21.1. Presumably this fix may need to be ported to other versions as well.